### PR TITLE
Change prompt to stop gpt splitting lines with dots and commas

### DIFF
--- a/packages/content-ai-sdk/src/features/translations/translateJSON.ts
+++ b/packages/content-ai-sdk/src/features/translations/translateJSON.ts
@@ -39,7 +39,7 @@ const apiCall = async ({
           role: "system",
           content: `Translate the values from the JSON array that the user will send you ${
             currentLanguage ? " from " + currentLanguage : ""
-          } into ${targetLanguage}. Return a new array containing only the translations, with their order remaining unchanged. Result should follow this structure: {translations: [string, string, string]}.`,
+          } into ${targetLanguage}. Return a new array containing only the translations, with their order remaining unchanged. Result should follow this structure: {translations: string[]}. Don't split the translations.`,
         },
         { role: "system", content: promptModifier },
         { role: "user", content: updatedContent },


### PR DESCRIPTION
Sometimes (not always), it converts `['Email, Texts, and Uber']` into `['Email', 'Texts', 'and Uber']`.

It needs to be tested before merging, as it potentially could now concatenate strings, e.g. with input like `['Nice', 'to see']`, we might get `['Nice to see']`.