### PR TITLE
pass custom prompt value to the sdk

### DIFF
--- a/packages/storyblok-ai-sdk/src/features/localization/localizeStory/index.ts
+++ b/packages/storyblok-ai-sdk/src/features/localization/localizeStory/index.ts
@@ -115,7 +115,7 @@ export const localizeStory = async (
           return translateJSON({
             targetLanguage: props.targetLanguageName,
             content: chunk,
-            promptModifier: props.promptModifier ? props.promptModifier : "",
+            promptModifier: props.promptModifier || "",
             isFlat: true,
             notTranslatableWords: props.notTranslatableWords,
           }).then((translatedChunk) => {

--- a/packages/storyblok-ai-tookit/src/components/Localization/CustomPromptInput.tsx
+++ b/packages/storyblok-ai-tookit/src/components/Localization/CustomPromptInput.tsx
@@ -1,0 +1,47 @@
+import { Dispatch } from 'react'
+import { LocalizationAction } from '.'
+import { TextareaAutosize, FormLabel } from '@mui/material'
+
+export default function CustomPromptInput({
+  value,
+  dispatch,
+}: ICustomPromptInput) {
+  return (
+    <div>
+      <FormLabel
+        style={{
+          marginTop: '12px',
+          marginBottom: '10px',
+          display: 'block',
+        }}
+      >
+        Custom prompt
+      </FormLabel>
+      <TextareaAutosize
+        value={value}
+        onChange={(e) =>
+          dispatch({
+            type: 'setCustomPrompt',
+            payload: e.target.value,
+          })
+        }
+        placeholder="Make all text sounds professional and formal"
+        style={{
+          width: '100%',
+          padding: '10px 18px',
+          border: '1px solid #ccc',
+          borderRadius: '4px',
+          fontSize: '14px',
+          boxSizing: 'border-box',
+          fontFamily: 'inherit',
+        }}
+        minRows={2}
+      />
+    </div>
+  )
+}
+
+interface ICustomPromptInput {
+  value: string
+  dispatch: Dispatch<LocalizationAction>
+}

--- a/packages/storyblok-ai-tookit/src/components/Localization/index.tsx
+++ b/packages/storyblok-ai-tookit/src/components/Localization/index.tsx
@@ -82,9 +82,10 @@ const Localization = () => {
           targetLanguageName: state.targetLanguageName,
           folderLevelTranslation: state.folderLevelTranslation,
           mode: 'update',
-          promptModifier: state.storySummary
-            ? `Use this text as a context, do not add it to the result translation: "${state.storySummary}"`
-            : '',
+          promptModifier:
+            state.customPrompt || state.storySummary
+              ? `Use this text as a context, do not add it to the result translation: "${state.storySummary}"`
+              : '',
           cb: () =>
             dispatch({
               type: 'endedSuccessfully',
@@ -273,6 +274,7 @@ export type LocalizationState = {
   targetLanguageName: string
   notTranslatableWords: NotTranslatableWords
   history: StateHistoryRecord[]
+  customPrompt: string
 }
 
 const INITIAL_STATE: LocalizationState = {
@@ -296,6 +298,7 @@ const INITIAL_STATE: LocalizationState = {
   isReadyToPerformLocalization: false,
   notTranslatableWords: { set: new Set(), new: null, limit: 10 },
   history: [{ time: new Date(Date.now()).toISOString(), action: 'init' }],
+  customPrompt: '',
 }
 
 export type LocalizationAction =
@@ -315,6 +318,7 @@ export type LocalizationAction =
   | { type: 'addNotTranslatableWord' }
   | { type: 'setNewNotTranslatableWord'; payload: string }
   | { type: 'setNotTranslatableWords'; payload: NotTranslatableWords }
+  | { type: 'setCustomPrompt'; payload: string }
 
 const reducer = (
   state: LocalizationState,
@@ -477,6 +481,12 @@ const reducer = (
           set: new Set(action.payload.set),
         },
         history: updatedHistory,
+      }
+
+    case 'setCustomPrompt':
+      return {
+        ...state,
+        customPrompt: action.payload,
       }
 
     case 'endedSuccessfully':

--- a/packages/storyblok-ai-tookit/src/components/Localization/modes/Story/index.tsx
+++ b/packages/storyblok-ai-tookit/src/components/Localization/modes/Story/index.tsx
@@ -22,6 +22,7 @@ import {
   TranslationLevels,
   TranslationModes,
 } from '@focus-reactive/storyblok-ai-sdk'
+import CustomPromptInput from '../../CustomPromptInput'
 
 interface ILocalizeStoryModeProps {
   localize: () => void
@@ -126,6 +127,10 @@ const LocalizeStoryMode: React.FC<ILocalizeStoryModeProps> = ({
           ))}
         />
       )}
+      <CustomPromptInput
+        dispatch={dispatch}
+        value={state.customPrompt}
+      />
       {showIgnoredWords ? (
         <Stack
           direction="column"


### PR DESCRIPTION
https://github.com/focusreactive/headless-cms-gpt-sdk/issues/24

- [ ] split prompt modifier and custom prompt into different paramethers. create 1 field for brand voice, create one for tone
- [ ] make AI understand that custom prompt could be a brand voice or tone or other type of instruction
- [ ] test
- [ ] implement the same params for sanity
- [ ] create issue for contentfull and payload plugins to implement brand voice and tone fields   